### PR TITLE
CRASH: Correctly support IPv6 in Solaris and derivatives

### DIFF
--- a/miltermodule.c
+++ b/miltermodule.c
@@ -282,7 +282,7 @@ $ python setup.py help
  * published.  Unfortunately I know of no good way to do this
  * other than with OS-specific tests.
  */
-#if defined(__FreeBSD__) || defined(__linux__)
+#if defined(__FreeBSD__) || defined(__linux__) || defined(__sun__)
 #define HAVE_IPV6_RFC2553
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
Library core dumps when SMTP IPv6 connections are notified. After debugging this issue for eight hours tonight I found this:

1. Under Solaris, pymilter doesn't do "#include <arpa/inet.h>".

2. Given that, we don't have a prototype of "inet_ntop()".

3. Given that, compiler assumes defaults when no prototype is available. Compiler assumes that "inet_ntop()" returns a signed integer.

4. pymilter uses "inet_ntop()" in function "makeip6addr()":

```
const char *s = inet_ntop(AF_INET6, &addr->sin6_addr, buf, sizeof buf);
```

5. Given those preconditions, the compiler will take a pointer (64 bits), will assume it is really a signed integer (32 bits) and then it will  convert it to a pointer (64 bits) via sign extension. The process loses information if the original pointer needs more than 32 bits.

In my debugging I am seeing this:

```
      - &buf = 0xfffffd7ff9400d10
      - s    = 0xfffffffff9400d10
```

Notice the difference.

After several preliminary patches, this pull request is quite minimal.
