### PR TITLE
Include arpa/inet.h on any GNU libc platform

### DIFF
--- a/miltermodule.c
+++ b/miltermodule.c
@@ -71,7 +71,7 @@ $ python setup.py help
  * published.  Unfortunately I know of no good way to do this
  * other than with OS-specific tests.
  */
-#if defined(__FreeBSD__) || defined(__linux__) || defined(__sun__)
+#if defined(__FreeBSD__) || defined(__linux__) || defined(__sun__) || defined(__GLIBC__)
 #define HAVE_IPV6_RFC2553
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
This header is provided by GNU libc on any platform, so include it unconditionally if `__GLIBC__` is defined.

Fixes #23.