### PR TITLE
Correctly document that body callback chunks are in bytes

### DIFF
--- a/miltermodule.c
+++ b/miltermodule.c
@@ -379,7 +379,7 @@ Sets the Python function invoked for each body chunk. There may\n\
 be multiple body chunks passed to the filter. End-of-lines are\n\
 represented as received from SMTP (normally Carriage-Return/Line-Feed).\n\
 Function takes args (ctx, chunk) -> int\n\
-chunk -> String - body data";
+chunk -> bytes - body data";
 
 static PyObject *
 milter_set_body_callback(PyObject *self, PyObject *args) {


### PR DESCRIPTION
https://github.com/sdgathman/pymilter/issues/12 says "Obviously, body
and replacebody are bytes" and milter_wrap_body in miltermodule.c
says:

   arglist = Py_BuildValue("(Oy#)", c, bodyp, bodylen);
…

So pymilter should sport the correct documentation.