### PR TITLE
Fix for compilation error on macOS 10.14 (Mojave)

### DIFF
--- a/miltermodule.c
+++ b/miltermodule.c
@@ -71,7 +71,7 @@ $ python setup.py help
  * published.  Unfortunately I know of no good way to do this
  * other than with OS-specific tests.
  */
-#if defined(__FreeBSD__) || defined(__linux__) || defined(__sun__) || defined(__GLIBC__)
+#if defined(__FreeBSD__) || defined(__linux__) || defined(__sun__) || defined(__GLIBC__) || (defined(__APPLE__) && defined(__MACH__))
 #define HAVE_IPV6_RFC2553
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
This change ensures that arpa/inet.h is included when building miltermodule.c on macOS 10.14. See #30 .
