### PR TITLE
adding required argument message_from_binary_file

### DIFF
--- a/template.py
+++ b/template.py
@@ -114,7 +114,7 @@ class myMilter(Milter.Base):
 
   def eom(self):
     self.fp.seek(0)
-    msg = email.message_from_binary_file(self.fp)
+    msg = email.message_from_binary_file(self.fp, policy=policy.default)
     # many milter functions can only be called from eom()
     # example of adding a Bcc:
     self.addrcpt('<%s>' % 'spy@example.com')


### PR DESCRIPTION
message_from_binary_file now has a required argument `policy` 
https://docs.python.org/3/library/email.parser.html#email.message_from_binary_file

In a future version a default will be added, but as of now, calling message_from_binary_file without policy will throw an error and not work
https://docs.python.org/3/library/email.parser.html#email.parser.BytesFeedParser