### PR TITLE
Welcome __NetBSD__ to the required header include.

### DIFF
--- a/miltermodule.c
+++ b/miltermodule.c
@@ -72,7 +72,7 @@ $ python setup.py help
  * published.  Unfortunately I know of no good way to do this
  * other than with OS-specific tests.
  */
-#if defined(__FreeBSD__) || defined(__linux__) || defined(__sun__) || defined(__GLIBC__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__linux__) || defined(__sun__) || defined(__GLIBC__) || (defined(__APPLE__) && defined(__MACH__))
 #define HAVE_IPV6_RFC2553
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
Same rule applies for NetBSD as FreeBSD, <arpa/inet.h> include is needed to provide inet_nto*() prototypes.