### PR TITLE
thread module has been renamed to _thread in Python 3

### DIFF
--- a/Milter/greylist.py
+++ b/Milter/greylist.py
@@ -1,7 +1,10 @@
 from __future__ import print_function
 import time
 import shelve
-import thread
+try:
+  import thread
+except:
+  import _thread as thread
 import logging
 import urllib
 


### PR DESCRIPTION
The same was done in `greysql.py`:
https://github.com/sdgathman/pymilter/blob/4a8018c2de882688054cdba9461ac518a53ac57d/Milter/greysql.py#L5-L8