### PR TITLE
Python 3.13: Replace deprecated makeSuite()

### DIFF
--- a/testcfg.py
+++ b/testcfg.py
@@ -11,7 +11,7 @@ class ConfigTestCase(unittest.TestCase):
     miltersrs = cp.getboolean('srsmilter','miltersrs')
     self.assertFalse(miltersrs)
 
-def suite(): return unittest.makeSuite(ConfigTestCase,'test')
+def suite(): return unittest.TestLoader().loadTestsFromTestCase(ConfigTestCase)
 
 if __name__ == '__main__':
   unittest.main()

--- a/testgrey.py
+++ b/testgrey.py
@@ -35,7 +35,7 @@ class GreylistTestCase(unittest.TestCase):
     # new one past expire
     rc = grey.check('1.2.3.5','foo@bar.com','baz@spat.com',timeinc=6*3600)
     self.assertEqual(rc,0)
-    # original past retain 
+    # original past retain
     rc = grey.check('1.2.3.4','foo@bar.com','baz@spat.com',timeinc=37*24*3600)
     self.assertEqual(rc,0)
     # new one for testing expire
@@ -48,8 +48,8 @@ class GreylistTestCase(unittest.TestCase):
     self.assertEqual(rc,1)
     grey.close()
 
-def suite(): 
-  s = unittest.makeSuite(GreylistTestCase,'test')
+def suite():
+  s = unittest.TestLoader().loadTestsFromTestCase(GreylistTestCase)
   return s
 
 if __name__ == '__main__':

--- a/testmime.py
+++ b/testmime.py
@@ -71,7 +71,7 @@ class MimeTestCase(unittest.TestCase):
         self.fail('should get boundary error parsing bad rfc822 attachment')
     except errors.BoundaryError:
       pass
-  
+
   def testDefang(self,vname='virus1',part=1,
 	fname='LOVE-LETTER-FOR-YOU.TXT.vbs'):
     try:
@@ -234,7 +234,7 @@ class MimeTestCase(unittest.TestCase):
     #print(msg + filter.msg)
     self.assertTrue(result.getvalue() == msg + filter.msg)
 
-def suite(): return unittest.makeSuite(MimeTestCase,'test')
+def suite(): return unittest.TestLoader().loadTestsFromTestCase(MimeTestCase)
 
 if __name__ == '__main__':
   if len(sys.argv) < 2:

--- a/testpolicy.py
+++ b/testpolicy.py
@@ -42,7 +42,7 @@ class PolicyTestCase(unittest.TestCase):
       pol = p.getPolicy('smtp-test')
     self.assertEqual(pol,'WILDCARD')
 
-def suite(): return unittest.makeSuite(PolicyTestCase,'test')
+def suite(): return unittest.TestLoader().loadTestsFromTestCase(PolicyTestCase)
 
 if __name__ == '__main__':
   if len(sys.argv) < 2:

--- a/testsample.py
+++ b/testsample.py
@@ -142,7 +142,7 @@ class BMSMilterTestCase(unittest.TestCase):
         f.write(fp.getvalue())
     milter.close()
 
-def suite(): return unittest.makeSuite(BMSMilterTestCase,'test')
+def suite(): return unittest.TestLoader().loadTestsFromTestCase(BMSMilterTestCase)
 
 if __name__ == '__main__':
   unittest.main()

--- a/testutils.py
+++ b/testutils.py
@@ -53,8 +53,8 @@ class AddrCacheTestCase(unittest.TestCase):
     s = Milter.utils.parseaddr('a(WRONG)@b')
     self.assertEqual(s,('WRONG', 'a@b'))
 
-def suite(): 
-  s = unittest.makeSuite(AddrCacheTestCase,'test')
+def suite():
+  s = unittest.TestLoader().loadTestsFromTestCase(AddrCacheTestCase)
   s.addTest(doctest.DocTestSuite(Milter.utils))
   s.addTest(doctest.DocTestSuite(Milter.dynip))
   s.addTest(doctest.DocTestSuite(Milter.pyip6))


### PR DESCRIPTION
The function has been deprecated in Python 3.11 and is no longer
available in Python 3.13.
